### PR TITLE
Utilize Bootstrap Nav

### DIFF
--- a/buhockeystatssite/static/css/style.css
+++ b/buhockeystatssite/static/css/style.css
@@ -3,21 +3,24 @@
 	src: url(fonts/college.ttf) format('truetype');
 }
 
-/* Common Styling */
-h1 {
-	color: white;
-	text-align: center;
-	padding: 10px;
+.nav-top-line {
 	font-family: college-font;
-	font-size: 60px;
+	width: 100%;
 }
 
-h2 {
-	color: white;
-	text-align: center;
-	padding: 10px;
-	font-size: 20px;
+@media (min-width: 576px) {
+	.nav-top-line {
+		width: auto;
+	}
+	.navbar-brand {
+		font-size: 60px;
+	}
+	.nav-item {
+		font-size: 30px;
+	}
 }
+
+/* Common Styling */
 a:hover {
   color: white;
   text-decoration: none;
@@ -212,12 +215,5 @@ hr{
 
 	#filterMenu {
 		display: none;
-	}
-
-	h2 {
-		color: white;
-		text-align: center;
-		padding: 10px;
-		font-size: 30px;
 	}
 }

--- a/buhockeystatssite/templates/layout.html
+++ b/buhockeystatssite/templates/layout.html
@@ -2,21 +2,39 @@
 <html lang="en" dir="ltr">
     <head>
         <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="{{ url_for('static', filename= 'css/style.css') }}">
-        <title>BU Hockey Stats</title>
         <link rel="icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>BU Hockey Stats</title>
     </head>
     <body>
-        <h1>BU Hockey Stats</h1>
-        <h2 class="clickable-heading">
-            <a class='link' href="/records">Records</a>
-            <a class='link' href="/players">Players</a>
-            <a class='link' href="/statsbot">Stats Bot</a>
-        </h2>
+        <nav class="navbar navbar-expand-sm navbar-dark d-flex flex-sm-column">
+            <div class="nav-top-line d-flex justify-content-between">
+                <span class="navbar-brand mb-0 h1">BU Hockey Stats</span>
+                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsible-nav" aria-controls="collapsible-nav" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+            </div>
+            <div class="collapse navbar-collapse" id="collapsible-nav">
+                <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
+                    <li class="nav-item">
+                        <a class='link' href="/records">Records</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class='link' href="/players">Players</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class='link' href="/statsbot">Stats Bot</a>
+                    </li>
+                </ul>
+            </div>
+        </nav>
         <div id="content">{% block content %}{% endblock %}</div>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     </body>
     <div id="footer">
         <hr>

--- a/buhockeystatssite/templates/players.html
+++ b/buhockeystatssite/templates/players.html
@@ -338,7 +338,4 @@
         });
       }
    </script>
-   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
-   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 {% endblock %}

--- a/buhockeystatssite/templates/records.html
+++ b/buhockeystatssite/templates/records.html
@@ -476,7 +476,4 @@
       {{resTable}}
       {% endautoescape %}
    </div>
-   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
-   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 {% endblock %}


### PR DESCRIPTION
Refactors the nav to use Bootstrap's nav component. Tried to keep the look the same while moving to more semantically correct elements. The nav will now collapse on small screens to give more screen space to the main content.

Also moved all the JS required for bootstrap into the layout.

**Mobile**
<img width="392" alt="image" src="https://github.com/redsoxfan2194/buhockeystatsbot/assets/6944977/de27e6bf-e838-4ab1-b2c7-979fcc60d28e">

**Dekstop**
<img width="1680" alt="image" src="https://github.com/redsoxfan2194/buhockeystatsbot/assets/6944977/99ede0f5-4b83-4523-9877-8627dba8178a">
